### PR TITLE
Add endpoint clash check

### DIFF
--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -970,13 +970,16 @@ class LitServer:
 
     def _register_spec_endpoints(self, lit_api: LitAPI):
         specs = [lit_api.spec] if lit_api.spec else []
+        existing_paths = {route.path for route in self.app.routes}
         for spec in specs:
             spec: LitSpec
-            # TODO check that path is not clashing
             for path, endpoint, methods in spec.endpoints:
+                if path in existing_paths:
+                    raise ValueError(f"Endpoint path '{path}' is already registered")
                 self.app.add_api_route(
                     path, endpoint=endpoint, methods=methods, dependencies=[Depends(self.setup_auth())]
                 )
+                existing_paths.add(path)
 
     def _register_middleware(self):
         for middleware in self.middlewares:


### PR DESCRIPTION
## Summary
- avoid path conflicts when registering spec endpoints
- test path conflict handling

## Testing
- `pytest tests/test_lit_server.py::test_spec_endpoint_path_clash -q`
- `pytest -q` *(fails: openai parity tests due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684c87bf05608333bc5f2996565ac9fd