### PR TITLE
feat: support async health checks

### DIFF
--- a/src/litserve/api.py
+++ b/src/litserve/api.py
@@ -16,6 +16,7 @@ import inspect
 import json
 import warnings
 from abc import ABC
+from collections.abc import Awaitable
 from queue import Queue
 from typing import TYPE_CHECKING, Callable, Optional, Union
 
@@ -360,14 +361,17 @@ class LitAPI(ABC, metaclass=_TimedInitMeta):
     def has_capacity(self) -> bool:
         raise NotImplementedError("has_capacity is not implemented")
 
-    def health(self) -> bool:
+    def health(self) -> bool | Awaitable[bool]:
         """Check the additional health status of the API.
 
         This method is used in the /health endpoint of the server to determine the health status.
         Users can extend this method to include additional health checks specific to their application.
 
+        The default implementation is synchronous but users may optionally implement an
+        ``async`` version which will be awaited by :class:`~litserve.server.LitServer`.
+
         Returns:
-            bool: True if the API is healthy, False otherwise.
+            bool: ``True`` if the API is healthy, ``False`` otherwise.
 
         """
         return True

--- a/src/litserve/server.py
+++ b/src/litserve/server.py
@@ -915,7 +915,14 @@ class LitServer:
             if not workers_ready:
                 workers_ready = all(v == WorkerSetupStatus.READY for v in self.workers_setup_status.values())
 
-            lit_api_health_status = all(lit_api.health() for lit_api in self.litapi_connector)
+            lit_api_health_status = True
+            for lit_api in self.litapi_connector:
+                result = lit_api.health()
+                if inspect.isawaitable(result):
+                    result = await result
+                if not result:
+                    lit_api_health_status = False
+                    break
             if workers_ready and lit_api_health_status:
                 return Response(content="ok", status_code=200)
 


### PR DESCRIPTION
## Summary
- allow `LitAPI.health` to be asynchronous
- await async health checks inside server health endpoint
- test async `health` method with LitServer

## Testing
- `ruff check src/litserve/api.py src/litserve/server.py tests/unit/test_simple.py`
- `python -m pytest tests/unit/test_simple.py::test_workers_health_with_async_health_method -q`
- `python -m pytest` *(fails: The `python-multipart` library must be installed to use form parsing; AssertionError in form tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c02313ae008333be9b6f14795d5254