### PR TITLE
Fix silent async stream failures in azip

### DIFF
--- a/src/litserve/utils.py
+++ b/src/litserve/utils.py
@@ -81,8 +81,11 @@ async def azip(*async_iterables):
     iterators = [ait.__aiter__() for ait in async_iterables]
     while True:
         results = await asyncio.gather(*(ait.__anext__() for ait in iterators), return_exceptions=True)
-        if any(isinstance(result, StopAsyncIteration) for result in results):
-            break
+        for result in results:
+            if isinstance(result, StopAsyncIteration):
+                return
+            if isinstance(result, Exception):
+                raise result
         yield tuple(results)
 
 


### PR DESCRIPTION
### Motivation

- `azip` could mask exceptions from upstream async iterators by returning exception objects as values, delaying and obscuring the real error cause.
- The behavior made streaming endpoints (e.g., OpenAI-style streaming) hard to debug and could lead to confusing downstream tuple-unpacking errors.

### Description

- Change `azip` in `src/litserve/utils.py` to immediately raise any exception produced by an async iterator and to stop cleanly when a `StopAsyncIteration` is encountered, preserving zip-like semantics.
- Add unit tests in `tests/unit/test_utils.py` to assert that `azip` stops at the shortest stream and that exceptions from a stream are propagated immediately.
- Import `azip` in the test module and add two `pytest.mark.asyncio` tests that cover the new behaviors.
- The change affects streaming reliability for components that consume `azip` (e.g., streaming responses in `specs/openai.py`).

### Testing

- Ran `pytest tests/unit/test_utils.py -q` after installing necessary test dependencies (`psutil`, `httpx`, `pytest-asyncio`) and installing the package in editable mode, and all tests passed.
- Result: `13 passed` for the unit tests in `tests/unit/test_utils.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994b9f44a3c833382fa81913d0db53f)